### PR TITLE
Two operations improvements

### DIFF
--- a/api/v1/zomboidserver_types.go
+++ b/api/v1/zomboidserver_types.go
@@ -24,6 +24,10 @@ type ZomboidServerSpec struct {
 	// +optional
 	Password *corev1.SecretKeySelector `json:"password,omitempty"`
 
+	// Suspended indicates whether the server should be running. If true, the server will be stopped.
+	// +optional
+	Suspended *bool `json:"suspended,omitempty"`
+
 	// Settings contains the server's current settings
 	// +optional
 	Settings ZomboidSettings `json:"settings,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1007,6 +1007,11 @@ func (in *ZomboidServerSpec) DeepCopyInto(out *ZomboidServerSpec) {
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Suspended != nil {
+		in, out := &in.Suspended, &out.Suspended
+		*out = new(bool)
+		**out = **in
+	}
 	in.Settings.DeepCopyInto(&out.Settings)
 }
 

--- a/config/crd/bases/horde.host_zomboidservers.yaml
+++ b/config/crd/bases/horde.host_zomboidservers.yaml
@@ -875,6 +875,10 @@ spec:
                 required:
                 - request
                 type: object
+              suspended:
+                description: Suspended indicates whether the server should be running.
+                  If true, the server will be stopped.
+                type: boolean
               version:
                 description: Version is the version of the Zomboid server to run.
                 type: string
@@ -967,6 +971,12 @@ spec:
                       AntiCheatProtectionType2:
                         default: true
                         type: boolean
+                      AntiCheatProtectionType2ThresholdMultiplier:
+                        default: 3
+                        description: Protection type threshold multipliers
+                        maximum: 10
+                        minimum: 1
+                        type: number
                       AntiCheatProtectionType3:
                         default: true
                         type: boolean
@@ -1065,12 +1075,6 @@ spec:
                         type: boolean
                       AntiCheatProtectionType24ThresholdMultiplier:
                         default: 6
-                        maximum: 10
-                        minimum: 1
-                        type: number
-                      AntiCheatProtectionType2ThresholdMultiplier:
-                        default: 3
-                        description: Protection type threshold multipliers
                         maximum: 10
                         minimum: 1
                         type: number

--- a/config/crd/bases/horde.host_zomboidservers.yaml
+++ b/config/crd/bases/horde.host_zomboidservers.yaml
@@ -967,12 +967,6 @@ spec:
                       AntiCheatProtectionType2:
                         default: true
                         type: boolean
-                      AntiCheatProtectionType2ThresholdMultiplier:
-                        default: 3
-                        description: Protection type threshold multipliers
-                        maximum: 10
-                        minimum: 1
-                        type: number
                       AntiCheatProtectionType3:
                         default: true
                         type: boolean
@@ -1071,6 +1065,12 @@ spec:
                         type: boolean
                       AntiCheatProtectionType24ThresholdMultiplier:
                         default: 6
+                        maximum: 10
+                        minimum: 1
+                        type: number
+                      AntiCheatProtectionType2ThresholdMultiplier:
+                        default: 3
+                        description: Protection type threshold multipliers
                         maximum: 10
                         minimum: 1
                         type: number

--- a/internal/controller/zomboidserver_controller.go
+++ b/internal/controller/zomboidserver_controller.go
@@ -479,11 +479,11 @@ func (r *ZomboidServerReconciler) reconcileDeployment(ctx context.Context, zombo
 										Command: []string{"/server/health"},
 									},
 								},
-								InitialDelaySeconds: 0,
-								PeriodSeconds:       2,
-								TimeoutSeconds:      1,
+								InitialDelaySeconds: 20,
+								PeriodSeconds:       5,
+								TimeoutSeconds:      2,
 								SuccessThreshold:    1,
-								FailureThreshold:    60,
+								FailureThreshold:    120, // 5 seconds * 120 attempts = 10 minutes
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/internal/controller/zomboidserver_controller.go
+++ b/internal/controller/zomboidserver_controller.go
@@ -400,8 +400,13 @@ func (r *ZomboidServerReconciler) reconcileDeployment(ctx context.Context, zombo
 			}
 		}
 
+		replicas := int32(1)
+		if zomboidServer.Spec.Suspended != nil && *zomboidServer.Spec.Suspended {
+			replicas = 0
+		}
+
 		deployment.Spec = appsv1.DeploymentSpec{
-			Replicas: ptr.To(int32(1)),
+			Replicas: ptr.To(replicas),
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},

--- a/internal/controller/zomboidserver_controller_test.go
+++ b/internal/controller/zomboidserver_controller_test.go
@@ -504,6 +504,52 @@ var _ = Describe("ZomboidServer Controller", func() {
 					Expect(deployment.Spec.Selector.MatchLabels).To(Equal(expectedLabels))
 					Expect(deployment.Spec.Template.Labels).To(Equal(expectedLabels))
 				})
+
+				It("should set replicas to 1 when not suspended", func() {
+					Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+				})
+
+				When("suspended is true", func() {
+					BeforeEach(func() {
+						zomboidServer.Spec.Suspended = ptr.To(true)
+						updateAndReconcile(ctx, k8sClient, reconciler, zomboidServer)
+
+						deployment = &appsv1.Deployment{}
+						Expect(k8sClient.Get(ctx, zomboidServerName, deployment)).To(Succeed())
+					})
+
+					It("should set replicas to 0", func() {
+						Expect(*deployment.Spec.Replicas).To(Equal(int32(0)))
+					})
+				})
+
+				When("suspended is false", func() {
+					BeforeEach(func() {
+						zomboidServer.Spec.Suspended = ptr.To(false)
+						updateAndReconcile(ctx, k8sClient, reconciler, zomboidServer)
+
+						deployment = &appsv1.Deployment{}
+						Expect(k8sClient.Get(ctx, zomboidServerName, deployment)).To(Succeed())
+					})
+
+					It("should set replicas to 1", func() {
+						Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+					})
+				})
+
+				When("suspended is nil", func() {
+					BeforeEach(func() {
+						zomboidServer.Spec.Suspended = nil
+						updateAndReconcile(ctx, k8sClient, reconciler, zomboidServer)
+
+						deployment = &appsv1.Deployment{}
+						Expect(k8sClient.Get(ctx, zomboidServerName, deployment)).To(Succeed())
+					})
+
+					It("should set replicas to 1", func() {
+						Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+					})
+				})
 			})
 
 			When("creating the Game Service", func() {

--- a/internal/controller/zomboidserver_controller_test.go
+++ b/internal/controller/zomboidserver_controller_test.go
@@ -399,11 +399,11 @@ var _ = Describe("ZomboidServer Controller", func() {
 								Command: []string{"/server/health"},
 							},
 						},
-						InitialDelaySeconds: 0,
-						PeriodSeconds:       2,
-						TimeoutSeconds:      1,
+						InitialDelaySeconds: 20,
+						PeriodSeconds:       5,
+						TimeoutSeconds:      2,
 						SuccessThreshold:    1,
-						FailureThreshold:    60,
+						FailureThreshold:    120, // 5 seconds * 120 attempts = 10 minutes
 					}))
 				})
 


### PR DESCRIPTION
- **Extending startup probe to 10 minutes**  Fixes #6
- **Adds a `suspended` flag for scaling a server down**  Fixes #4
